### PR TITLE
Change the improvement display in the performance demo

### DIFF
--- a/CompletedSourceCode/Performance/Program.cs
+++ b/CompletedSourceCode/Performance/Program.cs
@@ -160,8 +160,8 @@ namespace Performance
                 var efCore = stopwatch.ElapsedMilliseconds;
                 Console.WriteLine($"  - EF Core:    {efCore.ToString().PadLeft(4)}ms");
 
-                var result = (ef6 - efCore) / (double)ef6;
-                Console.WriteLine($"  - Improvement: {result.ToString("P0")}");
+                var result = ef6 / (double)efCore;
+                Console.WriteLine($"  - Speedup: {result.ToString("F1")}x");
                 Console.WriteLine();
             }
         }

--- a/StartingSourceCode/Performance/Program.cs
+++ b/StartingSourceCode/Performance/Program.cs
@@ -60,8 +60,8 @@ namespace Performance
                 var efCore = stopwatch.ElapsedMilliseconds;
                 Console.WriteLine($"  - EF Core:    {efCore.ToString().PadLeft(4)}ms");
 
-                var result = (ef6 - efCore) / (double)ef6;
-                Console.WriteLine($"  - Improvement: {result.ToString("P0")}");
+                var result = ef6 / (double)efCore;
+                Console.WriteLine($"  - Speedup: {result.ToString("F1")}x");
                 Console.WriteLine();
             }
         }


### PR DESCRIPTION
Hi,
I attended your BUILD 2016 session and it was awesome.
However, one thing that caught my eye is the visualization of the performance improvement which in my opinion is not displayed correctly. The demo displays improvement in percentage compared to the old performance, while it is more intuitive IMO to display [speedup](https://en.wikipedia.org/wiki/Speedup).

For example - if something takes 1000 ms in EF6 and 100 ms in EF Code, then the speedup is **10x** and not 90%. It also has an added benefit of being a much more impressive figure. :)

Regards,
Eran
